### PR TITLE
[WIP] Getting Deletion working

### DIFF
--- a/emr-dynamodb-hadoop/pom.xml
+++ b/emr-dynamodb-hadoop/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.amazon.emr</groupId>
         <artifactId>emr-dynamodb-connector</artifactId>
-        <version>4.2.0</version>
+        <version>4.2.5</version>
         <relativePath>../</relativePath>
     </parent>
 
@@ -59,5 +59,4 @@
         </dependency>
 
     </dependencies>
-
 </project>

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/DynamoDBConstants.java
@@ -58,6 +58,9 @@ public interface DynamoDBConstants {
   String MAX_MAP_TASKS = "dynamodb.max.map.tasks";
   String DEFAULT_THROUGHPUT_PERCENTAGE = "0.5";
 
+  String DELETION_MODE = "dynamodb.deletion.mode";
+  boolean DEFAULT_DELETION_MODE = false;
+
   double READ_EVENTUALLY_TO_STRONGLY_CONSISTENT_FACTOR = 2;
 
   String SCAN_SEGMENTS = "dynamodb.scan.segments";

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/util/TaskCalculator.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/util/TaskCalculator.java
@@ -15,6 +15,7 @@ package org.apache.hadoop.dynamodb.util;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.dynamodb.DynamoDBConstants;
 import org.apache.hadoop.mapred.JobClient;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapreduce.MRJobConfig;
@@ -41,6 +42,7 @@ public class TaskCalculator {
     // Total number of nodes in the cluster
     int nodes = jobClient.getClusterStatus().getTaskTrackers();
     log.info("Cluster has " + nodes + " active nodes.");
+    log.info("### DynamoDB Debug: " + conf.getBoolean(DynamoDBConstants.DELETION_MODE, DynamoDBConstants.DEFAULT_DELETION_MODE));
     if (nodes == 0) {
       log.warn("Cluster doesn't have any nodes");
       return 0;

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/write/AbstractDynamoDBOutputFormat.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/write/AbstractDynamoDBOutputFormat.java
@@ -13,6 +13,8 @@
 
 package org.apache.hadoop.dynamodb.write;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.mapred.JobConf;
 import org.apache.hadoop.mapred.OutputFormat;
@@ -20,8 +22,10 @@ import org.apache.hadoop.mapred.OutputFormat;
 import java.io.IOException;
 
 public abstract class AbstractDynamoDBOutputFormat<K, V> implements OutputFormat<K, V> {
+  private static final Log log = LogFactory.getLog(AbstractDynamoDBOutputFormat.class);
 
   @Override
   public void checkOutputSpecs(FileSystem arg0, JobConf arg1) throws IOException {
+    log.info("### AbstractDynamoDBOutputFormat");
   }
 }

--- a/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/write/DefaultDynamoDBRecordWriter.java
+++ b/emr-dynamodb-hadoop/src/main/java/org/apache/hadoop/dynamodb/write/DefaultDynamoDBRecordWriter.java
@@ -13,6 +13,8 @@
 
 package org.apache.hadoop.dynamodb.write;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.apache.hadoop.dynamodb.DynamoDBItemWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.JobConf;
@@ -22,9 +24,11 @@ import java.io.IOException;
 
 public class DefaultDynamoDBRecordWriter extends AbstractDynamoDBRecordWriter<Text,
     DynamoDBItemWritable> {
+  private static final Log log = LogFactory.getLog(DefaultDynamoDBRecordWriter.class);
 
   public DefaultDynamoDBRecordWriter(JobConf jobConf, Progressable progress) throws IOException {
     super(jobConf, progress);
+    log.info("### DefaultDynamoDBRecordWriter");
   }
 
   @Override

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.amazon.emr</groupId>
     <artifactId>emr-dynamodb-connector</artifactId>
-    <version>4.2.0</version>
+    <version>4.2.5</version>
     <packaging>pom</packaging>
 
     <name>EMRDynamoDBConnector</name>


### PR DESCRIPTION
Adding the functionality of DynamoDB deletion.

They would pass their intent to delete inside of the `JobConf`.

Something like this:
```java
JobConf jobConf = new JobConf(sc.hadoopConfiguration());
jobConf.set(DynamoDBConstants.INPUT_TABLE_NAME, INPUT_TABLE_NAME);
jobConf.set(DynamoDBConstants.OUTPUT_TABLE_NAME, OUTPUT_TABLE_NAME);
jobConf.set(DynamoDBConstants.DELETION_MODE, "true");

// Should be deleting.
filtered_results.saveAsHadoopDataset(jobConf);
```

# Problems:
1) I have done `mvn package` inside of the `emr-dynamodb-connector/emr-dynamodb-hadoop` and uploaded the jar to S3 
2) Whenever I run it, it just does not attempt to write.